### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 #fbadmin
 ## A python library to admin facebook groups that uses selenium and phantomjs behind the scenes
-[![Supported Python versions](https://pypip.in/py_versions/fbadmin/badge.svg)](https://pypi.python.org/pypi/<fbadmin>/)
-[![License](https://pypip.in/license/fbadmin/badge.svg)](https://pypi.python.org/pypi/fbadmin/)
-[![Development Status](https://pypip.in/status/fbadmin/badge.svg)](https://pypi.python.org/pypi/fbadmin/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/fbadmin.svg)](https://pypi.python.org/pypi/<fbadmin>/)
+[![License](https://img.shields.io/pypi/l/fbadmin.svg)](https://pypi.python.org/pypi/fbadmin/)
+[![Development Status](https://img.shields.io/pypi/status/fbadmin.svg)](https://pypi.python.org/pypi/fbadmin/)
 
 #### Note: This library is under active development. Lots more to come. To update 
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20fbadmin))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `fbadmin`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.